### PR TITLE
Polish: micro-interactions, tweaks panel, waveform strip

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,12 +7,15 @@ import Sidebar from "./components/Sidebar";
 import Dashboard from "./components/Dashboard";
 import UploadFlow from "./components/UploadFlow";
 import Editor from "./components/Editor";
+import TweaksPanel from "./components/TweaksPanel";
 
 export default function App() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<View>("dashboard");
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  const [showWaveform, setShowWaveform] = useState(false);
 
   useEffect(() => {
     listSessions()
@@ -43,6 +46,7 @@ export default function App() {
 
   return (
     <div
+      className={theme === "light" ? "theme-light" : undefined}
       style={{
         display: "grid",
         gridTemplateColumns: "240px 1fr",
@@ -90,6 +94,7 @@ export default function App() {
             session={activeSession}
             onUpdate={handleUpdate}
             onRemove={handleRemove}
+            showWaveform={showWaveform}
           />
         )}
 
@@ -102,6 +107,12 @@ export default function App() {
           </div>
         )}
       </main>
+      <TweaksPanel
+        theme={theme}
+        setTheme={setTheme}
+        showWaveform={showWaveform}
+        setShowWaveform={setShowWaveform}
+      />
     </div>
   );
 }

--- a/frontend/src/components/CueRail.tsx
+++ b/frontend/src/components/CueRail.tsx
@@ -75,7 +75,7 @@ export default function CueRail({
     >
       {/* Rail header */}
       <div style={{ padding: "14px 14px 10px", borderBottom: "1px solid var(--line-soft)", flexShrink: 0 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: showFR ? 10 : 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <span className="t-eyebrow">Cues</span>
           <div style={{ flex: 1 }} />
           <button
@@ -105,9 +105,15 @@ export default function CueRail({
           </button>
         </div>
 
-        {/* Find & replace bar */}
-        {showFR && (
-          <div style={{ display: "flex", gap: 6, alignItems: "center", paddingTop: 2 }}>
+        {/* Find & replace bar — height transition */}
+        <div
+          style={{
+            maxHeight: showFR ? 80 : 0,
+            overflow: "hidden",
+            transition: "max-height 0.18s ease",
+          }}
+        >
+          <div style={{ display: "flex", gap: 6, alignItems: "center", paddingTop: 8, paddingBottom: 2 }}>
             <input
               className="input"
               style={{ height: 28, fontSize: 12, flex: 1 }}
@@ -137,7 +143,7 @@ export default function CueRail({
               </span>
             )}
           </div>
-        )}
+        </div>
       </div>
 
       {/* Translate bar */}

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -20,6 +20,7 @@ import ModelPicker from "./ModelPicker";
 import ExportSheet from "./ExportSheet";
 import VideoStage from "./VideoStage";
 import CueRail from "./CueRail";
+import WaveformStrip from "./WaveformStrip";
 import StatusDot from "./ui/StatusDot";
 import Icon from "./ui/Icon";
 import { timestampToSeconds } from "../utils/time";
@@ -39,6 +40,7 @@ interface EditorProps {
   session: Session;
   onUpdate: (s: Session) => void;
   onRemove: (id: string) => void;
+  showWaveform?: boolean;
 }
 
 const LANG_ABBREV: Record<string, string> = {
@@ -57,7 +59,7 @@ function buildSrtFilename(videoFilename: string | null, lang: string | null): st
   return `${base}_srt_${langCode}_${ts}.srt`;
 }
 
-export default function Editor({ session, onUpdate, onRemove }: EditorProps) {
+export default function Editor({ session, onUpdate, onRemove, showWaveform = false }: EditorProps) {
   const s = session;
   const busy = s.status === "queued" || s.status === "processing";
 
@@ -190,7 +192,7 @@ export default function Editor({ session, onUpdate, onRemove }: EditorProps) {
         height: "100%",
         display: "grid",
         gridTemplateColumns: "1fr 440px",
-        gridTemplateRows: "auto 1fr",
+        gridTemplateRows: showWaveform ? "auto 1fr auto" : "auto 1fr",
         overflow: "hidden",
         position: "relative",
       }}
@@ -374,6 +376,16 @@ export default function Editor({ session, onUpdate, onRemove }: EditorProps) {
           if (videoRef.current) videoRef.current.currentTime = s;
         }}
       />
+
+      {/* Waveform strip */}
+      {showWaveform && (
+        <WaveformStrip
+          sessionId={s.id}
+          currentTime={currentTime}
+          duration={duration}
+          onSeek={(t) => { if (videoRef.current) videoRef.current.currentTime = t; }}
+        />
+      )}
 
       {/* Hidden SRT input */}
       <input

--- a/frontend/src/components/ExportSheet.tsx
+++ b/frontend/src/components/ExportSheet.tsx
@@ -42,6 +42,7 @@ export default function ExportSheet({
         zIndex: 50,
         gridColumn: "1 / -1",
         gridRow: "1 / -1",
+        animation: "modal-fade 0.15s ease",
       }}
     >
       <div
@@ -53,6 +54,7 @@ export default function ExportSheet({
           borderRadius: 14,
           padding: 24,
           boxShadow: "var(--shadow-lg)",
+          animation: "modal-slide 0.18s ease",
         }}
       >
         <div style={{ display: "flex", alignItems: "center", marginBottom: 18 }}>

--- a/frontend/src/components/ModelPicker.tsx
+++ b/frontend/src/components/ModelPicker.tsx
@@ -39,6 +39,7 @@ export default function ModelPicker({ open, current, onSelect, onClose }: ModelP
         zIndex: 50,
         gridColumn: "1 / -1",
         gridRow: "1 / -1",
+        animation: "modal-fade 0.15s ease",
       }}
     >
       <div
@@ -51,6 +52,7 @@ export default function ModelPicker({ open, current, onSelect, onClose }: ModelP
           borderRadius: 14,
           boxShadow: "var(--shadow-lg)",
           overflow: "hidden",
+          animation: "modal-slide 0.18s ease",
         }}
       >
         {/* Header */}

--- a/frontend/src/components/TweaksPanel.tsx
+++ b/frontend/src/components/TweaksPanel.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import Icon from "./ui/Icon";
+
+interface TweaksPanelProps {
+  theme: "dark" | "light";
+  setTheme: (t: "dark" | "light") => void;
+  showWaveform: boolean;
+  setShowWaveform: (v: boolean) => void;
+}
+
+export default function TweaksPanel({
+  theme,
+  setTheme,
+  showWaveform,
+  setShowWaveform,
+}: TweaksPanelProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 20,
+        right: 20,
+        zIndex: 40,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-end",
+        gap: 8,
+      }}
+    >
+      {/* Panel */}
+      <div
+        style={{
+          width: 228,
+          background: "var(--bg-1)",
+          border: "1px solid var(--line)",
+          borderRadius: 12,
+          boxShadow: "var(--shadow-lg)",
+          overflow: "hidden",
+          maxHeight: open ? 400 : 0,
+          opacity: open ? 1 : 0,
+          transition: "max-height 0.2s ease, opacity 0.15s ease",
+          pointerEvents: open ? "auto" : "none",
+        }}
+      >
+        {/* Appearance */}
+        <div style={{ padding: "12px 14px 10px", borderBottom: "1px solid var(--line-soft)" }}>
+          <div className="t-eyebrow" style={{ marginBottom: 10 }}>Appearance</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+            {(["dark", "light"] as const).map((t) => (
+              <button
+                key={t}
+                className={`btn sm${theme === t ? " primary" : " ghost"}`}
+                onClick={() => setTheme(t)}
+                style={{ justifyContent: "center", gap: 6 }}
+              >
+                <Icon name={t === "dark" ? "moon" : "sun"} size={12} />
+                {t === "dark" ? "Dark" : "Light"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Experimental */}
+        <div style={{ padding: "10px 14px 12px" }}>
+          <div className="t-eyebrow" style={{ marginBottom: 10 }}>Experimental</div>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              cursor: "pointer",
+              padding: "3px 0",
+              fontSize: 12,
+              color: "var(--text-2)",
+              userSelect: "none",
+            }}
+          >
+            <input
+              type="checkbox"
+              className="check"
+              checked={showWaveform}
+              onChange={(e) => setShowWaveform(e.target.checked)}
+            />
+            Waveform strip
+          </label>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              cursor: "not-allowed",
+              padding: "3px 0",
+              fontSize: 12,
+              color: "var(--text-4)",
+              userSelect: "none",
+              marginTop: 6,
+            }}
+          >
+            <input type="checkbox" className="check" disabled />
+            AI cue suggestions
+            <span className="pill" style={{ fontSize: 9, padding: "2px 6px", marginLeft: "auto" }}>
+              soon
+            </span>
+          </label>
+        </div>
+      </div>
+
+      {/* Toggle button */}
+      <button
+        className={`btn icon${open ? " primary" : ""}`}
+        onClick={() => setOpen((v) => !v)}
+        title="Tweaks"
+        style={{ boxShadow: "var(--shadow)" }}
+      >
+        <Icon name="settings" size={16} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/WaveformStrip.tsx
+++ b/frontend/src/components/WaveformStrip.tsx
@@ -1,0 +1,116 @@
+const BAR_COUNT = 160;
+
+function hashStr(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+function makeBars(seed: number): number[] {
+  let s = seed;
+  return Array.from({ length: BAR_COUNT }, () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    const raw = s / 0x7fffffff;
+    // Shape like a real waveform: mostly mid-height with occasional peaks
+    return 0.12 + Math.pow(raw, 0.55) * 0.88;
+  });
+}
+
+interface WaveformStripProps {
+  sessionId: string;
+  currentTime: number;
+  duration: number;
+  onSeek?: (t: number) => void;
+}
+
+export default function WaveformStrip({
+  sessionId,
+  currentTime,
+  duration,
+  onSeek,
+}: WaveformStripProps) {
+  const bars = makeBars(hashStr(sessionId));
+  const pct = duration > 0 ? currentTime / duration : 0;
+
+  function handleClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (!onSeek || duration <= 0) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const p = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    onSeek(p * duration);
+  }
+
+  return (
+    <div
+      style={{
+        gridColumn: "1 / -1",
+        height: 72,
+        background: "var(--bg-inset)",
+        borderTop: "1px solid var(--line-soft)",
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        padding: "0 28px",
+        gap: 1.5,
+        cursor: onSeek ? "pointer" : "default",
+        overflow: "hidden",
+        flexShrink: 0,
+      }}
+      onClick={handleClick}
+      title="Click to seek"
+    >
+      {/* Bars */}
+      {bars.map((h, i) => {
+        const barPct = i / BAR_COUNT;
+        const played = barPct < pct;
+        return (
+          <div
+            key={i}
+            style={{
+              flex: 1,
+              height: `${h * 100}%`,
+              maxHeight: 52,
+              borderRadius: 1.5,
+              background: played ? "var(--accent)" : "var(--line)",
+              opacity: played ? 0.85 : 0.5,
+              transition: "background 0.1s",
+              flexShrink: 0,
+            }}
+          />
+        );
+      })}
+
+      {/* Playhead */}
+      <div
+        style={{
+          position: "absolute",
+          left: `${pct * 100}%`,
+          top: 0,
+          bottom: 0,
+          width: 2,
+          background: "white",
+          borderRadius: 1,
+          pointerEvents: "none",
+          boxShadow: "0 0 6px oklch(100% 0 0 / 0.6)",
+          transform: "translateX(-50%)",
+        }}
+      />
+
+      {/* Label */}
+      <div
+        style={{
+          position: "absolute",
+          top: 6,
+          left: 28,
+          fontSize: 9.5,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: "var(--text-4)",
+          fontFamily: "var(--mono)",
+          pointerEvents: "none",
+        }}
+      >
+        Waveform (preview)
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -224,7 +224,31 @@ html, body {
 *::-webkit-scrollbar-thumb        { background: var(--line); border-radius: 999px; border: 2px solid transparent; background-clip: padding-box; }
 *::-webkit-scrollbar-thumb:hover  { background: var(--line-strong); border: 2px solid transparent; background-clip: padding-box; }
 
+/* ─── Checkbox ────────────────────────────────────────────────── */
+.check {
+  appearance: none; -webkit-appearance: none;
+  width: 16px; height: 16px; flex-shrink: 0;
+  border: 1.5px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg-2);
+  cursor: pointer;
+  position: relative;
+  transition: background 0.12s, border-color 0.12s;
+}
+.check:checked                { background: var(--accent); border-color: var(--accent); }
+.check:checked::after         { content: ''; position: absolute; left: 3px; top: 1.5px; width: 8px; height: 4.5px; border-left: 1.5px solid white; border-bottom: 1.5px solid white; transform: rotate(-45deg); }
+.check:focus                  { outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
+
 /* ─── Animations ──────────────────────────────────────────────── */
+@keyframes modal-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes modal-slide {
+  from { opacity: 0; transform: scale(0.97) translateY(6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
 @keyframes indeterminate {
   0%   { transform: translateX(-100%) scaleX(0.4); }
   50%  { transform: translateX(50%)   scaleX(0.6); }


### PR DESCRIPTION
## Summary
- **#18 Micro-interactions**: Modal fade/slide CSS animations for ModelPicker and ExportSheet; find & replace bar in CueRail now collapses with a max-height transition instead of hard conditional render; `.check` CSS class added for styled checkboxes
- **#16 Tweaks panel**: Floating bottom-right `TweaksPanel` component with dark/light theme toggle (wires into App-level `theme-light` class) and waveform strip experimental toggle
- **#17 Waveform strip**: `WaveformStrip` component with pseudo-random bars seeded deterministically from session ID; click-to-seek; playhead line; toggled via Tweaks panel; renders as a third row in the Editor grid

## Test plan
- [ ] Open ModelPicker and ExportSheet — verify fade-in on open
- [ ] Toggle find & replace in CueRail — verify smooth height animation
- [ ] Open Tweaks panel (gear icon, bottom-right) — verify panel slides open
- [ ] Switch dark ↔ light theme — verify full app re-themes
- [ ] Enable Waveform strip in Tweaks panel while in editor — verify strip appears below video/cue area
- [ ] Click waveform to seek — verify video position updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)