### PR TITLE
Cue view variants: list, timeline, two-pane, and AI suggestions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from "./components/Dashboard";
 import UploadFlow from "./components/UploadFlow";
 import Editor from "./components/Editor";
 import TweaksPanel from "./components/TweaksPanel";
+import type { SubtitleView } from "./components/TweaksPanel";
 
 export default function App() {
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -16,6 +17,8 @@ export default function App() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [theme, setTheme] = useState<"dark" | "light">("dark");
   const [showWaveform, setShowWaveform] = useState(false);
+  const [subtitleView, setSubtitleView] = useState<SubtitleView>("grid");
+  const [showAI, setShowAI] = useState(false);
 
   useEffect(() => {
     listSessions()
@@ -95,6 +98,8 @@ export default function App() {
             onUpdate={handleUpdate}
             onRemove={handleRemove}
             showWaveform={showWaveform}
+            subtitleView={subtitleView}
+            showAI={showAI}
           />
         )}
 
@@ -110,8 +115,12 @@ export default function App() {
       <TweaksPanel
         theme={theme}
         setTheme={setTheme}
+        subtitleView={subtitleView}
+        setSubtitleView={setSubtitleView}
         showWaveform={showWaveform}
         setShowWaveform={setShowWaveform}
+        showAI={showAI}
+        setShowAI={setShowAI}
       />
     </div>
   );

--- a/frontend/src/components/CueList.tsx
+++ b/frontend/src/components/CueList.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import type { Segment } from "../api/types";
+import { timestampToSeconds } from "../utils/time";
+
+interface CueListProps {
+  segments: Segment[];
+  currentTimeSeconds: number;
+  onSeek?: (t: number) => void;
+}
+
+export default function CueList({ segments, currentTimeSeconds, onSeek }: CueListProps) {
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [currentTimeSeconds]);
+
+  if (!segments.length) {
+    return (
+      <div style={{ padding: 32, color: "var(--text-4)", fontSize: 13, textAlign: "center" }}>
+        No cues
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", padding: "6px 0" }}>
+      {segments.map((seg) => {
+        const start = timestampToSeconds(seg.start);
+        const end   = timestampToSeconds(seg.end);
+        const isActive = currentTimeSeconds >= start && currentTimeSeconds < end;
+        return (
+          <div
+            key={seg.id}
+            ref={isActive ? activeRef : undefined}
+            onClick={() => onSeek?.(start)}
+            style={{
+              display: "flex",
+              gap: 10,
+              padding: "8px 14px",
+              cursor: "pointer",
+              background: isActive ? "var(--accent-soft)" : "transparent",
+              borderLeft: `2px solid ${isActive ? "var(--accent)" : "transparent"}`,
+              transition: "background 0.12s, border-color 0.12s",
+            }}
+            onMouseEnter={(e) => { if (!isActive) e.currentTarget.style.background = "var(--bg-2)"; }}
+            onMouseLeave={(e) => { if (!isActive) e.currentTarget.style.background = "transparent"; }}
+          >
+            <span
+              className="t-mono"
+              style={{ fontSize: 10, color: "var(--text-4)", minWidth: 18, paddingTop: 2, flexShrink: 0 }}
+            >
+              {seg.id}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="t-mono" style={{ fontSize: 10, color: "var(--text-3)", marginBottom: 3 }}>
+                {seg.start.substring(0, 8)} → {seg.end.substring(0, 8)}
+              </div>
+              <div
+                dir="auto"
+                style={{
+                  fontSize: 12.5,
+                  color: isActive ? "var(--text-1)" : "var(--text-2)",
+                  lineHeight: 1.45,
+                  wordBreak: "break-word",
+                }}
+              >
+                {seg.text}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/CueRail.tsx
+++ b/frontend/src/components/CueRail.tsx
@@ -1,8 +1,12 @@
 import { useRef, useState } from "react";
 import type { RefObject } from "react";
 import type { Session } from "../api/types";
+import type { Segment } from "../api/types";
 import type { SubtitleEditorHandle } from "./SubtitleEditor";
+import type { SubtitleView } from "./TweaksPanel";
 import SubtitleEditor from "./SubtitleEditor";
+import CueList from "./CueList";
+import CueTimeline from "./CueTimeline";
 import Icon from "./ui/Icon";
 
 const LANG_OPTIONS = [
@@ -16,8 +20,15 @@ const LANG_OPTIONS = [
   { code: "ru",   label: "Russian" },
 ];
 
+const AI_SUGGESTIONS = [
+  "Consider splitting this long cue at the natural pause.",
+  'Possible spelling: "their" instead of "there".',
+  "This cue overlaps the next by 80 ms — adjust timing?",
+];
+
 interface CueRailProps {
   session: Session;
+  segments: Segment[];
   subtitleVersion: number;
   onSave: () => void;
   srcLang: string;
@@ -29,10 +40,13 @@ interface CueRailProps {
   busy: boolean;
   currentTimeSeconds: number;
   onSeek: (s: number) => void;
+  subtitleView: SubtitleView;
+  showAI: boolean;
 }
 
 export default function CueRail({
   session: s,
+  segments,
   subtitleVersion,
   onSave,
   srcLang,
@@ -44,12 +58,16 @@ export default function CueRail({
   busy,
   currentTimeSeconds,
   onSeek,
+  subtitleView,
+  showAI,
 }: CueRailProps) {
   const editorRef = useRef<SubtitleEditorHandle>(null);
   const [showFR, setShowFR] = useState(false);
   const [findText, setFindText] = useState("");
   const [replaceText, setReplaceText] = useState("");
   const [replaceMsg, setReplaceMsg] = useState<string | null>(null);
+  const [aiIdx, setAiIdx] = useState(0);
+  const [aiDismissed, setAiDismissed] = useState(false);
 
   function handleReplaceAll() {
     const count = editorRef.current?.replaceAll(findText, replaceText) ?? 0;
@@ -61,6 +79,8 @@ export default function CueRail({
     await editorRef.current?.save();
     onSave();
   }
+
+  const useGrid = subtitleView === "grid" || subtitleView === "twopane";
 
   return (
     <aside
@@ -77,73 +97,84 @@ export default function CueRail({
       <div style={{ padding: "14px 14px 10px", borderBottom: "1px solid var(--line-soft)", flexShrink: 0 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <span className="t-eyebrow">Cues</span>
+          {segments.length > 0 && (
+            <span className="pill" style={{ fontSize: 9, padding: "2px 6px" }}>
+              {segments.length}
+            </span>
+          )}
           <div style={{ flex: 1 }} />
-          <button
-            className="btn sm ghost icon"
-            title="Find & replace"
-            onClick={() => setShowFR((v) => !v)}
-            style={{ background: showFR ? "var(--bg-2)" : undefined }}
-          >
-            <Icon name="search" size={13} />
-          </button>
-          <button
-            className="btn sm ghost icon"
-            title="Insert cue"
-            onClick={() => editorRef.current?.insertRowAfter()}
-          >
-            <Icon name="plus" size={13} />
-          </button>
-          <button
-            className="btn sm ghost icon"
-            title="Delete selected"
-            onClick={() => editorRef.current?.deleteSelected()}
-          >
-            <Icon name="trash" size={13} />
-          </button>
-          <button className="btn sm primary" onClick={handleSave} disabled={busy}>
-            <Icon name="save" size={12} /> Save
-          </button>
+          {useGrid && (
+            <>
+              <button
+                className="btn sm ghost icon"
+                title="Find & replace"
+                onClick={() => setShowFR((v) => !v)}
+                style={{ background: showFR ? "var(--bg-2)" : undefined }}
+              >
+                <Icon name="search" size={13} />
+              </button>
+              <button
+                className="btn sm ghost icon"
+                title="Insert cue"
+                onClick={() => editorRef.current?.insertRowAfter()}
+              >
+                <Icon name="plus" size={13} />
+              </button>
+              <button
+                className="btn sm ghost icon"
+                title="Delete selected"
+                onClick={() => editorRef.current?.deleteSelected()}
+              >
+                <Icon name="trash" size={13} />
+              </button>
+              <button className="btn sm primary" onClick={handleSave} disabled={busy}>
+                <Icon name="save" size={12} /> Save
+              </button>
+            </>
+          )}
         </div>
 
         {/* Find & replace bar — height transition */}
-        <div
-          style={{
-            maxHeight: showFR ? 80 : 0,
-            overflow: "hidden",
-            transition: "max-height 0.18s ease",
-          }}
-        >
-          <div style={{ display: "flex", gap: 6, alignItems: "center", paddingTop: 8, paddingBottom: 2 }}>
-            <input
-              className="input"
-              style={{ height: 28, fontSize: 12, flex: 1 }}
-              placeholder="Find…"
-              value={findText}
-              onChange={(e) => setFindText(e.target.value)}
-              dir="auto"
-            />
-            <input
-              className="input"
-              style={{ height: 28, fontSize: 12, flex: 1 }}
-              placeholder="Replace…"
-              value={replaceText}
-              onChange={(e) => setReplaceText(e.target.value)}
-              dir="auto"
-            />
-            <button
-              className="btn sm"
-              onClick={handleReplaceAll}
-              disabled={!findText}
-            >
-              All
-            </button>
-            {replaceMsg && (
-              <span style={{ fontSize: 11, color: "var(--text-3)", whiteSpace: "nowrap" }}>
-                {replaceMsg}
-              </span>
-            )}
+        {useGrid && (
+          <div
+            style={{
+              maxHeight: showFR ? 80 : 0,
+              overflow: "hidden",
+              transition: "max-height 0.18s ease",
+            }}
+          >
+            <div style={{ display: "flex", gap: 6, alignItems: "center", paddingTop: 8, paddingBottom: 2 }}>
+              <input
+                className="input"
+                style={{ height: 28, fontSize: 12, flex: 1 }}
+                placeholder="Find…"
+                value={findText}
+                onChange={(e) => setFindText(e.target.value)}
+                dir="auto"
+              />
+              <input
+                className="input"
+                style={{ height: 28, fontSize: 12, flex: 1 }}
+                placeholder="Replace…"
+                value={replaceText}
+                onChange={(e) => setReplaceText(e.target.value)}
+                dir="auto"
+              />
+              <button
+                className="btn sm"
+                onClick={handleReplaceAll}
+                disabled={!findText}
+              >
+                All
+              </button>
+              {replaceMsg && (
+                <span style={{ fontSize: 11, color: "var(--text-3)", whiteSpace: "nowrap" }}>
+                  {replaceMsg}
+                </span>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Translate bar */}
@@ -185,7 +216,7 @@ export default function CueRail({
         </div>
       )}
 
-      {/* SRT upload prompt (video uploaded, no subtitles yet) */}
+      {/* SRT upload prompt */}
       {s.capabilities.has_video && !s.capabilities.has_subtitles && (
         <div style={{ padding: "12px 14px", borderBottom: "1px solid var(--line-soft)", flexShrink: 0 }}>
           <p style={{ margin: "0 0 8px", fontSize: 13, color: "var(--text-2)" }}>
@@ -201,16 +232,72 @@ export default function CueRail({
         </div>
       )}
 
-      {/* Subtitle grid */}
+      {/* View body */}
       {s.capabilities.has_subtitles && (
-        <SubtitleEditor
-          ref={editorRef}
-          sessionId={s.id}
-          version={subtitleVersion}
-          onSave={onSave}
-          onSeek={onSeek}
-          currentTimeSeconds={currentTimeSeconds}
-        />
+        <>
+          {subtitleView === "timeline" ? (
+            <CueTimeline
+              segments={segments}
+              currentTimeSeconds={currentTimeSeconds}
+              onSeek={onSeek}
+            />
+          ) : subtitleView === "list" ? (
+            <CueList
+              segments={segments}
+              currentTimeSeconds={currentTimeSeconds}
+              onSeek={onSeek}
+            />
+          ) : (
+            /* grid or twopane — use SubtitleEditor (editable) */
+            <SubtitleEditor
+              ref={editorRef}
+              sessionId={s.id}
+              version={subtitleVersion}
+              onSave={onSave}
+              onSeek={onSeek}
+              currentTimeSeconds={currentTimeSeconds}
+            />
+          )}
+        </>
+      )}
+
+      {/* AI suggestions footer */}
+      {showAI && s.capabilities.has_subtitles && !aiDismissed && (
+        <div
+          style={{
+            borderTop: "1px solid var(--accent-line)",
+            background: "var(--accent-soft)",
+            padding: "10px 14px",
+            flexShrink: 0,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+            <Icon name="sparkles" size={13} style={{ color: "var(--accent)" }} />
+            <span style={{ fontSize: 11.5, fontWeight: 500, color: "var(--accent-hi)" }}>
+              AI suggestion
+            </span>
+            <span className="pill accent" style={{ fontSize: 9, padding: "2px 6px" }}>BETA</span>
+          </div>
+          <p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--text-2)", lineHeight: 1.4 }}>
+            {AI_SUGGESTIONS[aiIdx % AI_SUGGESTIONS.length]}
+          </p>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              className="btn sm primary"
+              style={{ fontSize: 11 }}
+              onClick={() => setAiIdx((i) => i + 1)}
+            >
+              Next
+            </button>
+            <button
+              className="btn sm ghost"
+              style={{ fontSize: 11 }}
+              onClick={() => setAiDismissed(true)}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
       )}
 
       {/* Replace SRT button at bottom */}

--- a/frontend/src/components/CueTimeline.tsx
+++ b/frontend/src/components/CueTimeline.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef } from "react";
+import type { Segment } from "../api/types";
+import { timestampToSeconds } from "../utils/time";
+
+interface CueTimelineProps {
+  segments: Segment[];
+  currentTimeSeconds: number;
+  onSeek?: (t: number) => void;
+}
+
+export default function CueTimeline({ segments, currentTimeSeconds, onSeek }: CueTimelineProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const totalDuration =
+    segments.length > 0
+      ? timestampToSeconds(segments[segments.length - 1].end)
+      : 60;
+
+  const playheadPct = (currentTimeSeconds / totalDuration) * 100;
+
+  // Keep playhead in view
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const target = (playheadPct / 100) * el.scrollWidth;
+    const left = target - el.clientWidth / 2;
+    el.scrollTo({ left: Math.max(0, left), behavior: "smooth" });
+  }, [currentTimeSeconds, playheadPct]);
+
+  if (!segments.length) {
+    return (
+      <div style={{ padding: 32, color: "var(--text-4)", fontSize: 13, textAlign: "center" }}>
+        No cues
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      style={{
+        flex: 1,
+        overflow: "auto",
+        position: "relative",
+        padding: "20px 0",
+        minHeight: 0,
+      }}
+    >
+      {/* Track background */}
+      <div
+        style={{
+          position: "relative",
+          height: 52,
+          minWidth: "100%",
+          width: `${Math.max(segments.length * 80, 800)}px`,
+          margin: "0 16px",
+        }}
+        onClick={(e) => {
+          if (!onSeek) return;
+          const rect = e.currentTarget.getBoundingClientRect();
+          const pct = (e.clientX - rect.left) / rect.width;
+          onSeek(pct * totalDuration);
+        }}
+      >
+        {/* Track line */}
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: 0,
+            right: 0,
+            height: 2,
+            background: "var(--line-soft)",
+            transform: "translateY(-50%)",
+          }}
+        />
+
+        {/* Segment blocks */}
+        {segments.map((seg) => {
+          const start    = timestampToSeconds(seg.start);
+          const end      = timestampToSeconds(seg.end);
+          const leftPct  = (start / totalDuration) * 100;
+          const widthPct = Math.max(((end - start) / totalDuration) * 100, 0.5);
+          const isActive = currentTimeSeconds >= start && currentTimeSeconds < end;
+          return (
+            <div
+              key={seg.id}
+              title={seg.text}
+              onClick={(e) => { e.stopPropagation(); onSeek?.(start); }}
+              style={{
+                position: "absolute",
+                left: `${leftPct}%`,
+                width: `${widthPct}%`,
+                minWidth: 4,
+                top: "50%",
+                transform: "translateY(-50%)",
+                height: isActive ? 36 : 28,
+                borderRadius: 4,
+                background: isActive ? "var(--accent)" : "var(--accent-soft)",
+                border: `1px solid ${isActive ? "var(--accent-hi)" : "var(--accent-line)"}`,
+                overflow: "hidden",
+                cursor: "pointer",
+                transition: "height 0.12s, background 0.12s",
+                display: "flex",
+                alignItems: "center",
+                padding: "0 5px",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 9.5,
+                  fontFamily: "var(--sans)",
+                  color: isActive ? "white" : "var(--accent-hi)",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  pointerEvents: "none",
+                }}
+              >
+                {seg.text}
+              </span>
+            </div>
+          );
+        })}
+
+        {/* Playhead */}
+        <div
+          style={{
+            position: "absolute",
+            left: `${playheadPct}%`,
+            top: 0,
+            bottom: 0,
+            width: 2,
+            background: "white",
+            borderRadius: 1,
+            pointerEvents: "none",
+            boxShadow: "0 0 4px oklch(100% 0 0 / 0.5)",
+            transform: "translateX(-50%)",
+          }}
+        />
+      </div>
+
+      {/* Time labels */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          padding: "6px 16px 0",
+          minWidth: `${Math.max(segments.length * 80, 800)}px`,
+        }}
+      >
+        {[0, 0.25, 0.5, 0.75, 1].map((frac) => {
+          const t = frac * totalDuration;
+          const m = Math.floor(t / 60);
+          const s = Math.floor(t % 60);
+          return (
+            <span
+              key={frac}
+              className="t-mono"
+              style={{ fontSize: 9.5, color: "var(--text-4)" }}
+            >
+              {String(m).padStart(2, "0")}:{String(s).padStart(2, "0")}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -24,6 +24,7 @@ import WaveformStrip from "./WaveformStrip";
 import StatusDot from "./ui/StatusDot";
 import Icon from "./ui/Icon";
 import { timestampToSeconds } from "../utils/time";
+import type { SubtitleView } from "./TweaksPanel";
 
 const LANG_OPTIONS = [
   { code: "auto", label: "Auto-detect" },
@@ -41,6 +42,8 @@ interface EditorProps {
   onUpdate: (s: Session) => void;
   onRemove: (id: string) => void;
   showWaveform?: boolean;
+  subtitleView?: SubtitleView;
+  showAI?: boolean;
 }
 
 const LANG_ABBREV: Record<string, string> = {
@@ -59,7 +62,14 @@ function buildSrtFilename(videoFilename: string | null, lang: string | null): st
   return `${base}_srt_${langCode}_${ts}.srt`;
 }
 
-export default function Editor({ session, onUpdate, onRemove, showWaveform = false }: EditorProps) {
+export default function Editor({
+  session,
+  onUpdate,
+  onRemove,
+  showWaveform = false,
+  subtitleView = "grid",
+  showAI = false,
+}: EditorProps) {
   const s = session;
   const busy = s.status === "queued" || s.status === "processing";
 
@@ -191,7 +201,7 @@ export default function Editor({ session, onUpdate, onRemove, showWaveform = fal
       style={{
         height: "100%",
         display: "grid",
-        gridTemplateColumns: "1fr 440px",
+        gridTemplateColumns: subtitleView === "twopane" ? "1fr 360px" : "1fr 440px",
         gridTemplateRows: showWaveform ? "auto 1fr auto" : "auto 1fr",
         overflow: "hidden",
         position: "relative",
@@ -362,6 +372,7 @@ export default function Editor({ session, onUpdate, onRemove, showWaveform = fal
       {/* Cue rail */}
       <CueRail
         session={s}
+        segments={segments}
         subtitleVersion={subtitleVersion}
         onSave={() => setSubtitleVersion((v) => v + 1)}
         srcLang={srcLang}
@@ -372,9 +383,11 @@ export default function Editor({ session, onUpdate, onRemove, showWaveform = fal
         srtRef={srtRef}
         busy={busy}
         currentTimeSeconds={currentTime}
-        onSeek={(s) => {
-          if (videoRef.current) videoRef.current.currentTime = s;
+        onSeek={(t) => {
+          if (videoRef.current) videoRef.current.currentTime = t;
         }}
+        subtitleView={subtitleView}
+        showAI={showAI}
       />
 
       {/* Waveform strip */}

--- a/frontend/src/components/TweaksPanel.tsx
+++ b/frontend/src/components/TweaksPanel.tsx
@@ -1,18 +1,36 @@
 import { useState } from "react";
 import Icon from "./ui/Icon";
+import type { IconName } from "./ui/Icon";
+
+export type SubtitleView = "grid" | "list" | "timeline" | "twopane";
+
+const VIEWS: { id: SubtitleView; icon: IconName; label: string }[] = [
+  { id: "grid",     icon: "grid",   label: "Grid" },
+  { id: "list",     icon: "list",   label: "List" },
+  { id: "timeline", icon: "film",   label: "Timeline" },
+  { id: "twopane",  icon: "split",  label: "Two-pane" },
+];
 
 interface TweaksPanelProps {
   theme: "dark" | "light";
   setTheme: (t: "dark" | "light") => void;
+  subtitleView: SubtitleView;
+  setSubtitleView: (v: SubtitleView) => void;
   showWaveform: boolean;
   setShowWaveform: (v: boolean) => void;
+  showAI: boolean;
+  setShowAI: (v: boolean) => void;
 }
 
 export default function TweaksPanel({
   theme,
   setTheme,
+  subtitleView,
+  setSubtitleView,
   showWaveform,
   setShowWaveform,
+  showAI,
+  setShowAI,
 }: TweaksPanelProps) {
   const [open, setOpen] = useState(false);
 
@@ -32,13 +50,13 @@ export default function TweaksPanel({
       {/* Panel */}
       <div
         style={{
-          width: 228,
+          width: 240,
           background: "var(--bg-1)",
           border: "1px solid var(--line)",
           borderRadius: 12,
           boxShadow: "var(--shadow-lg)",
           overflow: "hidden",
-          maxHeight: open ? 400 : 0,
+          maxHeight: open ? 500 : 0,
           opacity: open ? 1 : 0,
           transition: "max-height 0.2s ease, opacity 0.15s ease",
           pointerEvents: open ? "auto" : "none",
@@ -62,6 +80,25 @@ export default function TweaksPanel({
           </div>
         </div>
 
+        {/* Subtitle view */}
+        <div style={{ padding: "10px 14px", borderBottom: "1px solid var(--line-soft)" }}>
+          <div className="t-eyebrow" style={{ marginBottom: 10 }}>Subtitle view</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 4 }}>
+            {VIEWS.map((v) => (
+              <button
+                key={v.id}
+                className={`btn sm icon${subtitleView === v.id ? " primary" : " ghost"}`}
+                onClick={() => setSubtitleView(v.id)}
+                title={v.label}
+                style={{ flexDirection: "column", height: 40, gap: 4, fontSize: 9 }}
+              >
+                <Icon name={v.icon} size={13} />
+                {v.label.split("-")[0]}
+              </button>
+            ))}
+          </div>
+        </div>
+
         {/* Experimental */}
         <div style={{ padding: "10px 14px 12px" }}>
           <div className="t-eyebrow" style={{ marginBottom: 10 }}>Experimental</div>
@@ -71,7 +108,7 @@ export default function TweaksPanel({
               alignItems: "center",
               gap: 10,
               cursor: "pointer",
-              padding: "3px 0",
+              padding: "4px 0",
               fontSize: 12,
               color: "var(--text-2)",
               userSelect: "none",
@@ -90,18 +127,23 @@ export default function TweaksPanel({
               display: "flex",
               alignItems: "center",
               gap: 10,
-              cursor: "not-allowed",
-              padding: "3px 0",
+              cursor: "pointer",
+              padding: "4px 0",
               fontSize: 12,
-              color: "var(--text-4)",
+              color: "var(--text-2)",
               userSelect: "none",
-              marginTop: 6,
+              marginTop: 2,
             }}
           >
-            <input type="checkbox" className="check" disabled />
+            <input
+              type="checkbox"
+              className="check"
+              checked={showAI}
+              onChange={(e) => setShowAI(e.target.checked)}
+            />
             AI cue suggestions
-            <span className="pill" style={{ fontSize: 9, padding: "2px 6px", marginLeft: "auto" }}>
-              soon
+            <span className="pill accent" style={{ fontSize: 9, padding: "2px 6px", marginLeft: "auto" }}>
+              BETA
             </span>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- **#13 Cue view variants**: New `CueList` (card per cue, active row highlighted, click to seek) and `CueTimeline` (horizontal proportional blocks with playhead and click-to-seek). Two-pane mode narrows the cue rail to 360px to give more room to the video.
- **TweaksPanel**: Added a subtitle view switcher (4 icon buttons: Grid / List / Timeline / Two-pane) and an AI suggestions toggle (enabled with a BETA label).
- **AI suggestions panel**: When enabled, a footer panel appears in the cue rail with an accent-soft background, sparkles icon, cycling placeholder suggestions, and Next/Dismiss actions.
- **CueRail**: Now receives `segments` from Editor so list/timeline views can display data without a separate fetch.

## Test plan
- [ ] Open Tweaks panel → switch to List view — verify card list with timecodes and seek-on-click
- [ ] Switch to Timeline view — verify horizontal blocks proportional to clip length, playhead tracks video
- [ ] Switch to Two-pane view — verify cue rail narrows to 360px
- [ ] Switch back to Grid — verify AG Grid editing works as before
- [ ] Enable AI suggestions in Tweaks — verify footer appears with "Next" / "Dismiss" buttons
- [ ] Dismiss AI panel — verify it hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)